### PR TITLE
Fix release workflow runner availability

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,13 +55,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: macos-13
-            target: x86_64-apple-darwin
+          - target: x86_64-apple-darwin
             asset_name: marmotd-x86_64-darwin
-          - runner: macos-14
-            target: aarch64-apple-darwin
+          - target: aarch64-apple-darwin
             asset_name: marmotd-aarch64-darwin
-    runs-on: ${{ matrix.runner }}
+    runs-on: macos-14
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- switch release macOS builds to `macos-14` for both darwin targets
- remove unsupported `macos-13` runner from matrix

## Why
The release workflow failed on tag `v0.1.0` with:
`The configuration \`macos-13-us-default\` is not supported`

## Effect
Release workflow can run in this repo/org and produce both darwin artifacts via CI.
