### PR TITLE
Ensure release workflow installs each build target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,9 @@ jobs:
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
+
+      - name: Add target
+        run: rustup target add "${{ matrix.target }}"
 
       - name: Set up Zig
         uses: goto-bus-stop/setup-zig@v2
@@ -66,8 +67,9 @@ jobs:
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
+
+      - name: Add target
+        run: rustup target add "${{ matrix.target }}"
 
       - name: Build binary
         run: cargo build -p marmotd --release --target "${{ matrix.target }}"


### PR DESCRIPTION
## Summary
- add explicit `rustup target add ${{ matrix.target }}` in both linux and macOS release jobs
- keep existing cross-platform artifact matrix unchanged

## Why
Tag release `v0.1.1` failed on `x86_64-apple-darwin` because target stdlib was not installed.

## Effect
Release workflow consistently has the required target toolchain before build.
