### PR TITLE
Fix release workflow Linux sqlcipher build path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,21 +4,24 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 permissions:
   contents: write
 
 jobs:
   build-linux:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
             asset_name: marmotd-x86_64-linux
+            runner: ubuntu-24.04
           - target: aarch64-unknown-linux-gnu
             asset_name: marmotd-aarch64-linux
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,14 +32,8 @@ jobs:
       - name: Add target
         run: rustup target add "${{ matrix.target }}"
 
-      - name: Set up Zig
-        uses: goto-bus-stop/setup-zig@v2
-
-      - name: Install cargo-zigbuild
-        run: cargo install cargo-zigbuild --locked
-
       - name: Build binary
-        run: cargo zigbuild -p marmotd --release --target "${{ matrix.target }}"
+        run: cargo build -p marmotd --release --target "${{ matrix.target }}"
 
       - name: Stage artifact
         run: |


### PR DESCRIPTION
## Summary
- remove Zig-based Linux cross compilation from release workflow
- build Linux artifacts on native per-arch GitHub runners instead
- keep macOS builds as-is and enable manual 

## Why
 was failing to compile sqlcipher ( missing) for Linux release targets.
