### PR TITLE
fix: rename npm package to resolve plugin ID mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Use Marmot as an [OpenClaw](https://openclaw.dev) channel plugin so your AI agen
 ### 1. Install the plugin
 
 ```bash
-openclaw plugins install @justinmoon/openclaw-marmot
+openclaw plugins install @justinmoon/marmot
 ```
 
 This installs the plugin via npm. The `marmotd` sidecar binary is auto-downloaded on first launch (Linux and macOS, x64 and arm64).

--- a/docs/npm-publish.md
+++ b/docs/npm-publish.md
@@ -1,14 +1,14 @@
 ---
 summary: Runbook for publishing the Marmot plugin package to npm with passkey/browser 2FA.
 read_when:
-  - when publishing a new @justinmoon/openclaw-marmot version
+  - when publishing a new @justinmoon/marmot version
   - when npm publish prompts for browser authentication or OTP
 ---
 
 # npm publish
 
 Package:
-- `@justinmoon/openclaw-marmot`
+- `@justinmoon/marmot`
 
 ## Standard publish flow
 
@@ -28,10 +28,10 @@ Then:
 1. Press Enter in the terminal.
 2. Approve in browser/1Password passkey prompt.
 3. Wait for success output:
-   - `+ @justinmoon/openclaw-marmot@<version>`
+   - `+ @justinmoon/marmot@<version>`
 
 ## Post-publish smoke check
 
 ```sh
-openclaw plugins install @justinmoon/openclaw-marmot
+openclaw plugins install @justinmoon/marmot
 ```

--- a/openclaw/extensions/marmot/package.json
+++ b/openclaw/extensions/marmot/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@justinmoon/openclaw-marmot",
+  "name": "@justinmoon/marmot",
   "version": "0.0.0",
   "description": "OpenClaw Marmot channel plugin (Rust sidecar)",
   "type": "module",
@@ -24,7 +24,7 @@
       "quickstartAllowFrom": true
     },
     "install": {
-      "npmSpec": "@justinmoon/openclaw-marmot",
+      "npmSpec": "@justinmoon/marmot",
       "localPath": "extensions/marmot",
       "defaultChoice": "path"
     }


### PR DESCRIPTION
Renames the npm package from `@justinmoon/openclaw-marmot` to `@justinmoon/marmot` so OpenClaw's derived plugin ID hint (`marmot`) matches the manifest ID (`marmot`).

This silences the warning on every gateway start:
```
plugins.entries.marmot: plugin marmot: plugin id mismatch (manifest uses "marmot", entry hints "openclaw-marmot")
```

Changes:
- `package.json`: name + npmSpec updated
- `README.md`: install command updated  
- `docs/npm-publish.md`: package references updated

Fixes #12