### PR TITLE
fix: rename plugin to marmotclaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Use Marmot as an [OpenClaw](https://openclaw.dev) channel plugin so your AI agen
 ### 1. Install the plugin
 
 ```bash
-openclaw plugins install @justinmoon/openclaw-marmot
+openclaw plugins install @justinmoon/marmotclaw
 ```
 
 This installs the plugin via npm. The `marmotd` sidecar binary is auto-downloaded on first launch (Linux and macOS, x64 and arm64).
@@ -56,7 +56,7 @@ Add the channel config to `~/.openclaw/openclaw.json`:
 ```json
 {
   "channels": {
-    "marmot": {
+    "marmotclaw": {
       "relays": ["wss://relay.damus.io", "wss://nos.lol", "wss://relay.primal.net"],
       "sidecarCmd": "marmotd",
       "stateDir": "~/.openclaw/.marmot-state",
@@ -79,7 +79,7 @@ Quick setup for group chats — add these fields to your `channels.marmot` confi
 ```json
 {
   "channels": {
-    "marmot": {
+    "marmotclaw": {
       "groupPolicy": "open",
       "groupAllowFrom": ["<owner-pubkey>", "<friend-pubkey>"],
       "owner": "<owner-pubkey>",

--- a/docs/group-chat.md
+++ b/docs/group-chat.md
@@ -20,7 +20,7 @@ The Marmot plugin supports multi-participant MLS group chats over Nostr. Your bo
 ```json
 {
   "channels": {
-    "marmot": {
+    "marmotclaw": {
       "relays": ["wss://relay.damus.io", "wss://nos.lol", "wss://relay.primal.net"],
       "sidecarCmd": "marmotd",
       "stateDir": "~/.openclaw/.marmot-state",
@@ -65,7 +65,7 @@ Per-group settings:
 ```json
 {
   "channels": {
-    "marmot": {
+    "marmotclaw": {
       "groups": {
         "*": { "requireMention": true },
         "<specific-group-id>": { "requireMention": false }

--- a/docs/npm-publish.md
+++ b/docs/npm-publish.md
@@ -1,14 +1,14 @@
 ---
 summary: Runbook for publishing the Marmot plugin package to npm with passkey/browser 2FA.
 read_when:
-  - when publishing a new @justinmoon/openclaw-marmot version
+  - when publishing a new @justinmoon/marmotclaw version
   - when npm publish prompts for browser authentication or OTP
 ---
 
 # npm publish
 
 Package:
-- `@justinmoon/openclaw-marmot`
+- `@justinmoon/marmotclaw`
 
 ## Standard publish flow
 
@@ -28,10 +28,10 @@ Then:
 1. Press Enter in the terminal.
 2. Approve in browser/1Password passkey prompt.
 3. Wait for success output:
-   - `+ @justinmoon/openclaw-marmot@<version>`
+   - `+ @justinmoon/marmotclaw@<version>`
 
 ## Post-publish smoke check
 
 ```sh
-openclaw plugins install @justinmoon/openclaw-marmot
+openclaw plugins install @justinmoon/marmotclaw
 ```

--- a/openclaw/extensions/marmot/index.ts
+++ b/openclaw/extensions/marmot/index.ts
@@ -4,7 +4,7 @@ import { marmotPluginConfigSchema } from "./src/config-schema.js";
 import { setMarmotRuntime } from "./src/runtime.js";
 
 const plugin = {
-  id: "marmot",
+  id: "marmotclaw",
   name: "Marmot",
   description: "Marmot MLS group messaging over Nostr (Rust sidecar)",
   configSchema: marmotPluginConfigSchema,

--- a/openclaw/extensions/marmot/openclaw.plugin.json
+++ b/openclaw/extensions/marmot/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
-  "id": "marmot",
-  "channels": ["marmot"],
+  "id": "marmotclaw",
+  "channels": ["marmotclaw"],
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/openclaw/extensions/marmot/package.json
+++ b/openclaw/extensions/marmot/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@justinmoon/openclaw-marmot",
+  "name": "@justinmoon/marmotclaw",
   "version": "0.0.0",
   "description": "OpenClaw Marmot channel plugin (Rust sidecar)",
   "type": "module",
@@ -14,17 +14,17 @@
       "./index.ts"
     ],
     "channel": {
-      "id": "marmot",
+      "id": "marmotclaw",
       "label": "Marmot",
       "selectionLabel": "Marmot (Rust)",
       "docsPath": "/channels/marmot",
-      "docsLabel": "marmot",
+      "docsLabel": "marmotclaw",
       "blurb": "MLS E2EE groups over Nostr (Rust sidecar).",
       "order": 56,
       "quickstartAllowFrom": true
     },
     "install": {
-      "npmSpec": "@justinmoon/openclaw-marmot",
+      "npmSpec": "@justinmoon/marmotclaw",
       "localPath": "extensions/marmot",
       "defaultChoice": "path"
     }

--- a/openclaw/extensions/marmot/src/channel.ts
+++ b/openclaw/extensions/marmot/src/channel.ts
@@ -234,7 +234,7 @@ function isDmGroup(chatId: string, cfg: any): boolean {
 }
 
 function resolveRequireMention(chatId: string, cfg: any): boolean {
-  // Check channels.marmot.groups config
+  // Check channels.marmotclaw.groups config
   const groups = cfg?.channels?.marmot?.groups ?? {};
   const groupConfig = groups[chatId] ?? groups["*"];
   if (groupConfig && typeof groupConfig.requireMention === "boolean") {
@@ -283,8 +283,8 @@ async function dispatchInboundToAgent(params: {
     To: chatId,
     ...(isGroupChat ? { SessionKey: `marmot:${accountId}:${chatId}` } : {}),
     AccountId: accountId,
-    Provider: "marmot",
-    Surface: "marmot",
+    Provider: "marmotclaw",
+    Surface: "marmotclaw",
     ChatType: chatType,
     SenderId: senderId,
     SenderName: senderName,
@@ -380,13 +380,13 @@ function resolveSidecarArgs(cfgArgs?: string[] | null): string[] | null {
 }
 
 export const marmotPlugin: ChannelPlugin<ResolvedMarmotAccount> = {
-  id: "marmot",
+  id: "marmotclaw",
   meta: {
-    id: "marmot",
+    id: "marmotclaw",
     label: "Marmot",
     selectionLabel: "Marmot (Rust)",
     docsPath: "/channels/marmot",
-    docsLabel: "marmot",
+    docsLabel: "marmotclaw",
     blurb: "MLS E2EE groups over Nostr (Rust sidecar).",
     order: 56,
     quickstartAllowFrom: true,
@@ -396,7 +396,7 @@ export const marmotPlugin: ChannelPlugin<ResolvedMarmotAccount> = {
     media: false,
     nativeCommands: false,
   },
-  reload: { configPrefixes: ["channels.marmot", "plugins.entries.marmot"] },
+  reload: { configPrefixes: ["channels.marmotclaw", "plugins.entries.marmotclaw"] },
 
   config: {
     listAccountIds: (cfg) => listMarmotAccountIds(cfg),
@@ -435,9 +435,9 @@ export const marmotPlugin: ChannelPlugin<ResolvedMarmotAccount> = {
     resolveDmPolicy: () => ({
       policy: "pairing",
       allowFrom: [],
-      policyPath: "channels.marmot.dmPolicy",
-      allowFromPath: "channels.marmot.allowFrom",
-      approveHint: formatPairingApproveHint("marmot"),
+      policyPath: "channels.marmotclaw.dmPolicy",
+      allowFromPath: "channels.marmotclaw.allowFrom",
+      approveHint: formatPairingApproveHint("marmotclaw"),
       normalizeEntry: (raw) => raw.replace(/^marmot:/i, "").trim().toLowerCase(),
     }),
   },
@@ -464,7 +464,7 @@ export const marmotPlugin: ChannelPlugin<ResolvedMarmotAccount> = {
         throw new Error(`invalid marmot group id: ${to}`);
       }
       await handle.sidecar.sendMessage(groupId, text ?? "");
-      return { channel: "marmot", to: groupId };
+      return { channel: "marmotclaw", to: groupId };
     },
     sendMedia: async () => {
       throw new Error("marmot does not support media");
@@ -482,7 +482,7 @@ export const marmotPlugin: ChannelPlugin<ResolvedMarmotAccount> = {
         throw new Error("marmot account disabled");
       }
       if (!resolved.configured) {
-        throw new Error("marmot relays not configured (channels.marmot.relays)");
+        throw new Error("marmot relays not configured (channels.marmotclaw.relays)");
       }
 
       const relays = resolved.config.relays.map((r) => String(r).trim()).filter(Boolean);


### PR DESCRIPTION
⚠️ **Breaking change** — requires config updates.

Renames the plugin from `marmot` to `marmotclaw` to resolve the plugin ID mismatch warning (#12) and give it a less generic name.

### Changes
- npm package: `@justinmoon/openclaw-marmot` → `@justinmoon/marmotclaw`
- Plugin ID / channel / provider / surface: `marmot` → `marmotclaw`
- All config paths: `channels.marmot` → `channels.marmotclaw`
- Docs and README updated

### Migration
Users need to update their `openclaw.json`:
```diff
- "plugins": { "entries": { "marmot": { ... } } }
+ "plugins": { "entries": { "marmotclaw": { ... } } }

- "channels": { "marmot": { ... } }
+ "channels": { "marmotclaw": { ... } }
```

Fixes #12