### PR TITLE
fix: make relays optional in plugin schema + guard duplicate startAccount

### DIFF
--- a/openclaw/extensions/marmot/openclaw.plugin.json
+++ b/openclaw/extensions/marmot/openclaw.plugin.json
@@ -63,6 +63,6 @@
         "items": { "type": "string" }
       }
     },
-    "required": ["relays"]
+    "required": []
   }
 }

--- a/openclaw/extensions/marmot/src/config-schema.ts
+++ b/openclaw/extensions/marmot/src/config-schema.ts
@@ -37,5 +37,5 @@ export const marmotPluginConfigSchema = {
       },
     },
   },
-  required: ["relays"],
+  required: [],
 } as const;


### PR DESCRIPTION
## Problems

1. **Startup failure:** When OpenClaw auto-creates `plugins.entries.marmot` with an empty config, schema validation fails because `relays` is required. This prevents the gateway from starting entirely.

2. **Duplicate sidecar race:** If `startAccount` is called concurrently, multiple marmotd processes can spawn for the same account due to async gaps between the guard check and `activeSidecars.set()`.

## Fixes

### 1. Make `relays` optional in plugin config schema
- `openclaw.plugin.json`: `required: ["relays"]` → `required: []`
- `config-schema.ts`: same change

Relays are still required at runtime — `startAccount` checks the `configured` flag and throws a descriptive error if relays are missing. This just prevents schema validation from killing the gateway on boot.

### 2. Guard duplicate `startAccount` with immediate sentinel
- `channel.ts`: Set a sentinel value in `activeSidecars` immediately (before any `await`s) to prevent race conditions.

## Testing

Both issues hit in production. Verified fixes on a live deployment. 🦞