### PR TITLE
fix: add bech32 as dependency

### DIFF
--- a/openclaw/extensions/marmot/package.json
+++ b/openclaw/extensions/marmot/package.json
@@ -6,6 +6,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "dependencies": {
+    "bech32": "^2.0.0"
+  },
   "peerDependencies": {
     "openclaw": ">=2026.1.0"
   },


### PR DESCRIPTION
The `bech32` module is required at runtime but wasn't listed in `package.json`, causing `Cannot find module 'bech32'` errors on fresh installs.

Adds `bech32@^2.0.0` to `dependencies`.