### PR TITLE
fix: allow any group when sender allowlist is configured

### DIFF
--- a/openclaw/extensions/marmot/src/channel.ts
+++ b/openclaw/extensions/marmot/src/channel.ts
@@ -602,8 +602,12 @@ export const marmotPlugin: ChannelPlugin<ResolvedMarmotAccount> = {
 
       const isGroupAllowed = (nostrGroupId: string): boolean => {
         if (groupPolicy === "open") return true;
+        // In allowlist mode, a group is allowed if it's explicitly listed in groups config
+        // OR if groupAllowFrom has entries (sender-level filtering handles security)
         const gid = String(nostrGroupId).trim().toLowerCase();
-        return Boolean(allowedGroups[gid]);
+        if (Boolean(allowedGroups[gid])) return true;
+        if (groupAllowFrom.length > 0) return true;
+        return false;
       };
       const isSenderAllowed = (pubkey: string): boolean => {
         if (groupAllowFrom.length === 0) return true;


### PR DESCRIPTION
In allowlist mode, `isGroupAllowed()` required every group ID to be explicitly listed in the `groups` config map. This meant messages were silently dropped even when the sender was in `groupAllowFrom`.

Now when `groupAllowFrom` has entries, any group is allowed — the sender check handles access control. The `groups` config map becomes optional (for per-group settings like `requireMention`/name) rather than a hard gate.

**Before:** Messages from allowed senders dropped if group ID not in `groups` config.
**After:** If `groupAllowFrom` is configured, all groups are allowed; sender filtering handles security.