### PR TITLE
feat: support multiple relay connections

### DIFF
--- a/marmotd/src/main.rs
+++ b/marmotd/src/main.rs
@@ -57,9 +57,9 @@ enum Command {
 
     /// Long-running JSONL sidecar daemon intended to be embedded/invoked by OpenClaw.
     Daemon {
-        /// Relay websocket URL, e.g. ws://127.0.0.1:18080
+        /// Relay websocket URL(s), e.g. wss://relay.damus.io. Repeatable.
         #[arg(long, default_value = "ws://127.0.0.1:18080")]
-        relay: String,
+        relay: Vec<String>,
 
         /// Folder-local state directory (will be created if missing)
         #[arg(long, default_value = ".state/marmotd")]

--- a/openclaw/extensions/marmot/src/channel.ts
+++ b/openclaw/extensions/marmot/src/channel.ts
@@ -564,9 +564,10 @@ export const marmotPlugin: ChannelPlugin<ResolvedMarmotAccount> = {
         requestedCmd: requestedSidecarCmd,
         log: ctx.log,
       });
+      const relayArgs = (relays.length > 0 ? relays : ["ws://127.0.0.1:18080"]).flatMap((r) => ["--relay", r]);
       const sidecarArgs =
         resolveSidecarArgs(resolved.config.sidecarArgs) ??
-        ["daemon", "--relay", relays[0] ?? "ws://127.0.0.1:18080", "--state-dir", baseStateDir];
+        ["daemon", ...relayArgs, "--state-dir", baseStateDir];
 
       ctx.log?.info(
         `[${resolved.accountId}] 🦞 MOLTATHON MARMOT v0.2.0 — starting sidecar cmd=${JSON.stringify(sidecarCmd)} args=${JSON.stringify(sidecarArgs)}`,


### PR DESCRIPTION
The sidecar previously only connected to the first relay in the config list. Messages sent through other relays were silently dropped — this caused DMs to fail when the client (e.g. Pika) routed through a different relay than the one the sidecar was listening on.

### Changes

**marmotd (Rust):**
- `--relay` flag now accepts multiple values (`Vec<String>`, repeatable)
- All relays are added to the nostr client on startup
- Primary relay (first in list) used for initial connectivity check

**Plugin (TypeScript):**
- Passes all configured relays to the sidecar via repeated `--relay` flags
- `["daemon", "--relay", "wss://relay.damus.io", "--relay", "wss://nos.lol", ..., "--state-dir", ...]`

### Before
```
marmotd daemon --relay wss://relay.damus.io --state-dir ...
```
Only one relay, messages on other relays silently dropped.

### After
```
marmotd daemon --relay wss://relay.damus.io --relay wss://nos.lol --relay wss://relay.primal.net --state-dir ...
```
All configured relays connected. The `set_relays` JSONL command still works for runtime changes.

### Testing
Tested with 3 relays (damus, nos.lol, primal). DMs and group chats both working across all relays.

Built and verified locally — includes Rust binary compilation.