### PR TITLE
feat: add pika-html-update instructions to group system prompt

### DIFF
--- a/openclaw/extensions/marmot/src/channel.ts
+++ b/openclaw/extensions/marmot/src/channel.ts
@@ -735,6 +735,9 @@ export const marmotPlugin: ChannelPlugin<ResolvedMarmotAccount> = {
                 groupName: groupNames.get(groupId),
                 stateDir: baseStateDir,
                 deliverText: async (responseText: string) => {
+                  ctx.log?.info(
+                    `[${resolved.accountId}] send group=${ev.nostr_group_id} len=${responseText.length}`,
+                  );
                   await sidecar.sendMessage(ev.nostr_group_id, responseText);
                 },
                 log: ctx.log,
@@ -750,6 +753,9 @@ export const marmotPlugin: ChannelPlugin<ResolvedMarmotAccount> = {
                 isOwner: senderIsOwner,
                 isGroupChat: false,
                 deliverText: async (responseText: string) => {
+                  ctx.log?.info(
+                    `[${resolved.accountId}] send dm=${ev.nostr_group_id} len=${responseText.length}`,
+                  );
                   await sidecar.sendMessage(ev.nostr_group_id, responseText);
                 },
                 log: ctx.log,

--- a/openclaw/extensions/marmot/src/channel.ts
+++ b/openclaw/extensions/marmot/src/channel.ts
@@ -282,7 +282,8 @@ const GROUP_SYSTEM_PROMPT = [
   "Load GROUP_MEMORY.md for shared context. Never reference MEMORY.md or secrets in groups.",
   'To create a poll, send a pika-prompt code block: ```pika-prompt\n{"title":"Your question?","options":["Option A","Option B","Option C"]}\n```',
   'When users vote, you\'ll see messages like [Voted "Option A"]. Track votes to determine results.',
-  'To send rich HTML content (forms, styled widgets, visualizations), use a pika-html code block: ```pika-html\n<h1>Hello</h1>\n```',
+  'To send rich HTML content (forms, styled widgets, visualizations), use a pika-html code block with a short ID: ```pika-html my-widget\n<h1>Hello</h1>\n```',
+  'Always include an ID after pika-html (e.g. "dashboard", "search-results"). To update it later, send: ```pika-html-update my-widget\n<h1>Updated</h1>\n``` The update replaces the original inline.',
   "The HTML renders in an inline WebView in the app. You can include CSS styles inline or in a <style> tag.",
   "To let users send a message back from the HTML, use the JS bridge: window.pika.send(\"message text\").",
 ].join(" ");

--- a/openclaw/extensions/marmot/src/sidecar.ts
+++ b/openclaw/extensions/marmot/src/sidecar.ts
@@ -182,6 +182,7 @@ export class MarmotSidecar {
   }
 
   async sendMessage(nostrGroupId: string, content: string): Promise<void> {
+    getMarmotRuntime().logger?.info(`[marmotd] send group=${nostrGroupId} len=${content.length}`);
     await this.request({ cmd: "send_message", nostr_group_id: nostrGroupId, content } as any);
   }
 

--- a/openclaw/extensions/marmot/src/sidecar.ts
+++ b/openclaw/extensions/marmot/src/sidecar.ts
@@ -182,7 +182,6 @@ export class MarmotSidecar {
   }
 
   async sendMessage(nostrGroupId: string, content: string): Promise<void> {
-    getMarmotRuntime().logger?.info(`[marmotd] send group=${nostrGroupId} len=${content.length}`);
     await this.request({ cmd: "send_message", nostr_group_id: nostrGroupId, content } as any);
   }
 


### PR DESCRIPTION
Teach the bot about updatable HTML WebViews: how to assign an ID to a pika-html block and how to send pika-html-update to replace it in-place.